### PR TITLE
Refector process.env into centralized config file

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -1,5 +1,6 @@
 const Command = require('../library/command');
 const Commands = require('../library/commands');
+const config = require('../config/config');
 
 /**
  * @class Help
@@ -23,7 +24,7 @@ class Help extends Command {
     // Considered moving this to the Commands class
     let longest = 0;
     commands.names.map((commandName) => {
-      commandName = `${process.env.MESSAGE_PREFIX}${commandName}`;
+      commandName = `${config.messagePrefix}${commandName}`;
       if (commandName.length > longest) {
         longest = commandName.length;
       }
@@ -33,7 +34,7 @@ class Help extends Command {
     longest += 1;
     commands.names.map((commandName) => {
       let command = commands.get(commandName);
-      helpMsg += `${process.env.MESSAGE_PREFIX}${commandName}`;
+      helpMsg += `${config.messagePrefix}${commandName}`;
       // TODO: needs args implemented here after they're part of the magic
       const spaces = longest - commandName.length;
       for (let i = 0; i < spaces; i++) {

--- a/commands/search.js
+++ b/commands/search.js
@@ -1,4 +1,5 @@
 const Command = require('../library/command');
+const config = require('../config/config');
 const superagent = require('superagent');
 
 /**
@@ -13,10 +14,8 @@ class Search extends Command {
   }
 
   static execute(args, msg) {
-    const { key } = process.env.GOOGLE_API_KEY;
-    const { cx } = process.env.GOOGLE_SEARCH_ENGINE_ID;
     const { channel } = msg;
-    const url = `https://www.googleapis.com/customsearch/v1?key=${key}&cx=${cx}&safe=off&q=${encodeURI(args)}`;
+    const url = `https://www.googleapis.com/customsearch/v1?key=${config.googleApiKey}&cx=${config.googleSearchEngineId}&safe=off&q=${encodeURI(args)}`;
 
     superagent.get(url).end((err, res) => {
       if (err) {

--- a/commands/version.js
+++ b/commands/version.js
@@ -1,4 +1,5 @@
 const Command = require('../library/command');
+const config = require('../config/config')
 const { version } = require('../package.json');
 
 /**
@@ -14,7 +15,7 @@ class Version extends Command {
 
   static execute(args, msg) {
     const { channel } = msg;
-    let nodeEnv = process.env.NODE_ENV;
+    let nodeEnv = config.env;
     let runningEnv = nodeEnv ? `${nodeEnv} ` : '';
     return channel.sendMessage(`Hackbot ${runningEnv}is running v${version}`);
   }

--- a/commands/weather.js
+++ b/commands/weather.js
@@ -1,3 +1,4 @@
+const config = require('../config/config')
 const Command = require('../library/command');
 const request = require('request');
 
@@ -19,7 +20,7 @@ class Weather extends Command {
     const getWeather = location => new Promise((resolve, reject) => {
       const encodedLocation = encodeURIComponent(location);
       const url = `http://api.openweathermap.org/data/2.5/weather?q=${encodedLocation}
-                   us&units=imperial&appid=${process.env.OPEN_WEATHERMAP_KEY}`;
+                   us&units=imperial&appid=${config.openWeathermapKey}`;
       location.map((location) => {
         const trimmedLocation = (location.trim());
         const isInt = parseInt(trimmedLocation);

--- a/config/config.js
+++ b/config/config.js
@@ -1,0 +1,18 @@
+require('dotenv').config();
+
+const defaults = {
+  defaultChannel: process.env.DEFAULT_CHANNEL,
+  discordAppToken: process.env.DISCORD_APP_TOKEN,
+  env: process.env.NODE_ENV || 'production',
+  messagePrefix: process.env.MESSAGE_PREFIX,
+  production: process.env.NODE_ENV === 'production'
+};
+
+const plugins = {
+  googleApiKey: process.env.GOOGLE_API_KEY,
+  googleSearchEngineId: process.env.GOOGLE_SEARCH_ENGINE_ID,
+  openWeathermapKey: process.env.OPEN_WEATHERMAP_KEY
+};
+
+// defaults overwrite plugins
+module.exports = Object.assign(plugins, defaults);

--- a/hackbot.js
+++ b/hackbot.js
@@ -1,10 +1,10 @@
-require('dotenv').config();
+const config = require('./config/config');
 const Discord = require('discord.js');
 const CommandParser = require('./library/command-parser');
 const Commands = require('./library/commands');
 
 const bot = new Discord.Client();
-const cmdParser = new CommandParser(process.env.MESSAGE_PREFIX);
+const cmdParser = new CommandParser(config.messagePrefix);
 const commands = new Commands();
 
 bot.on('ready', () => {
@@ -14,8 +14,8 @@ bot.on('ready', () => {
 
 bot.on('message', msg => {
   if (
-    !msg.content.startsWith(process.env.MESSAGE_PREFIX) ||
-    msg.content.length <= process.env.MESSAGE_PREFIX.length
+    !msg.content.startsWith(config.messagePrefix) ||
+    msg.content.length <= config.messagePrefix.length
   ) {
     return;
   } else {
@@ -31,13 +31,13 @@ bot.on('message', msg => {
   }
 });
 
-if (process.env.NODE_ENV === 'production') {
+if (config.production) {
   bot.on('guildMemberAdd', (member) => {
     var { username, id } = member.user;
     console.log(`New User '${username}' has joined '${member.guild.name}'`);
 
     const defaultChannel = member.guild.defaultChannel
-      || member.guild.channels.find('name', process.env.DEFAULT_CHANNEL);
+      || member.guild.channels.find('name', config.defaultChannel);
 
     if (defaultChannel) {
       defaultChannel.send(`'${username}' has joined this server`);
@@ -50,4 +50,4 @@ if (process.env.NODE_ENV === 'production') {
 
 bot.on('error', e => { console.error(e); });
 
-bot.login(process.env.DISCORD_APP_TOKEN);
+bot.login(config.discordAppToken);


### PR DESCRIPTION
Decouples `process.env` usage in code into an encapsulated config file.

Fixes #48 