### PR TITLE
#31 - Add Test Coverage

### DIFF
--- a/__tests__/commands/__snapshots__/help.test.ts.snap
+++ b/__tests__/commands/__snapshots__/help.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Help Command Execute DMs commands with prefix and descriptions it still looks the same 1`] = `
+"I am here to help! Well...mostly just make you chuckle at this point, let's be honest.
+
+Here is a list of the commands that we've got right now:
+\`\`\`
+!one       → I am number one.
+!two       → Two is not just a number.
+!blueFish  → Not a red fish.
+\`\`\`"
+`;

--- a/__tests__/commands/help.test.ts
+++ b/__tests__/commands/help.test.ts
@@ -76,6 +76,10 @@ describe('Help Command', () => {
         expect(lastLine).toEqual('```');
       });
 
+      test('it still looks the same', () => {
+        expect(message).toMatchSnapshot();
+      });
+
       describe('Commands', () => {
         test('one command', () => {
           expect(message).toContain('!one');

--- a/__tests__/commands/help.test.ts
+++ b/__tests__/commands/help.test.ts
@@ -2,7 +2,7 @@ import Help from '../../src/commands/help';
 import { message as mockMessage, MockedMessage } from '../mocks/discord';
 import Commands from '../../src/library/commands';
 
-// TODO: These should be in a factor/mock
+// TODO: These should be in a factory/mock
 const oneCommand = {
   name: 'one',
   description: 'I am number one.',

--- a/__tests__/commands/help.test.ts
+++ b/__tests__/commands/help.test.ts
@@ -1,6 +1,6 @@
 import Help from '../../src/commands/help';
-import { message as mockMessage, MockedMessage } from '../mocks/discord';
 import Commands from '../../src/library/commands';
+import { message as mockMessage, MockedMessage } from '../mocks/discord';
 
 // TODO: These should be in a factory/mock
 const oneCommand = {
@@ -13,7 +13,7 @@ const twoCommand = {
   name: 'two',
   description: 'Two is not just a number.',
   execute: jest.fn()
-}
+};
 
 const blueFishCommand = {
   name: 'blueFish',
@@ -36,7 +36,7 @@ beforeEach(() => {
   // @ts-ignore
   mockMessage.author = {
     send: authorSend
-  }
+  };
 });
 
 describe('Help Command', () => {
@@ -86,7 +86,7 @@ describe('Help Command', () => {
         });
 
         test('one description', () => {
-          expect(message).toContain(oneCommand.description)
+          expect(message).toContain(oneCommand.description);
         });
 
         test('two command', () => {

--- a/__tests__/commands/help.test.ts
+++ b/__tests__/commands/help.test.ts
@@ -1,0 +1,98 @@
+import Help from '../../src/commands/help';
+import { message as mockMessage, MockedMessage } from '../mocks/discord';
+
+const commands:{[key: string]: {[key: string]: string}} = {
+  One: { description: 'I am number one.' },
+  Two: { description: 'Two is not just a number.' },
+  BlueFish: { description: 'Not a red fish.' }
+};
+
+jest.mock('../../src/library/commands', () => {
+  return function() {
+    return {
+      longestName: jest.fn(() => 42),
+      names: Object.keys(commands),
+      get: jest.fn((name) => {
+        return commands[name];
+      })
+    };
+  }
+});
+
+let sendMock: MockedMessage;
+let authorSend: MockedMessage;
+beforeEach(() => {
+  sendMock = jest.fn();
+  mockMessage.reply = sendMock;
+  authorSend = jest.fn();
+  // @ts-ignore
+  mockMessage.author = {
+    send: authorSend
+  }
+});
+
+describe('Help Command', () => {
+  describe('Execute', () => {
+    beforeEach(() => {
+      Help.execute([], mockMessage);
+    });
+
+    test('Lets you know to check your DMs', () => {
+      expect(sendMock).lastCalledWith('sliding into your DMs...');
+    });
+
+    describe('DMs commands with prefix and descriptions', () => {
+      let message: string;
+      beforeEach(() => {
+        message = authorSend.mock.calls[0][0];
+      });
+
+      test('Snarky', () => {
+        const snark = "I am here to help! Well...mostly just make you chuckle " +
+          "at this point, let's be honest.";
+        expect(message).toContain(snark);
+      });
+
+      test('Command pretext header', () => {
+        const pretext = "Here is a list of the commands that we've got right now:";
+        expect(message).toContain(pretext);
+      });
+
+      test('Code block start', () => {
+        expect(message).toContain('```\n');
+      });
+
+      test('Code block end', () => {
+        const lines = message.split('\n');
+        const lastLine = lines[lines.length - 1];
+        expect(lastLine).toEqual('```');
+      });
+
+      describe('Commands', () => {
+        test('One command', () => {
+          expect(message).toContain('!One');
+        });
+  
+        test('One description', () => {
+          expect(message).toContain(commands.One.description)
+        });
+  
+        test('Two command', () => {
+          expect(message).toContain('!Two');
+        });
+  
+        test('Two description', () => {
+          expect(message).toContain(commands.Two.description);
+        });
+  
+        test('BlueFish command', () => {
+          expect(message).toContain('!BlueFish');
+        });
+  
+        test('BlueFish description', () => {
+          expect(message).toContain(commands.BlueFish.description);
+        });
+      });
+    });
+  });
+});

--- a/__tests__/commands/help.test.ts
+++ b/__tests__/commands/help.test.ts
@@ -1,22 +1,30 @@
 import Help from '../../src/commands/help';
 import { message as mockMessage, MockedMessage } from '../mocks/discord';
+import Commands from '../../src/library/commands';
 
-const commands:{[key: string]: {[key: string]: string}} = {
-  One: { description: 'I am number one.' },
-  Two: { description: 'Two is not just a number.' },
-  BlueFish: { description: 'Not a red fish.' }
+// TODO: These should be in a factor/mock
+const oneCommand = {
+  name: 'one',
+  description: 'I am number one.',
+  execute: jest.fn()
 };
 
-jest.mock('../../src/library/commands', () => {
-  return function() {
-    return {
-      longestName: jest.fn(() => 42),
-      names: Object.keys(commands),
-      get: jest.fn((name) => {
-        return commands[name];
-      })
-    };
-  }
+const twoCommand = {
+  name: 'two',
+  description: 'Two is not just a number.',
+  execute: jest.fn()
+}
+
+const blueFishCommand = {
+  name: 'blueFish',
+  description: 'Not a red fish.',
+  execute: jest.fn()
+};
+
+const commands = new Commands({
+  one: oneCommand,
+  two: twoCommand,
+  blueFish: blueFishCommand
 });
 
 let sendMock: MockedMessage;
@@ -34,7 +42,7 @@ beforeEach(() => {
 describe('Help Command', () => {
   describe('Execute', () => {
     beforeEach(() => {
-      Help.execute([], mockMessage);
+      Help.execute([], mockMessage, { commands });
     });
 
     test('Lets you know to check your DMs', () => {
@@ -69,28 +77,28 @@ describe('Help Command', () => {
       });
 
       describe('Commands', () => {
-        test('One command', () => {
-          expect(message).toContain('!One');
+        test('one command', () => {
+          expect(message).toContain('!one');
         });
-  
-        test('One description', () => {
-          expect(message).toContain(commands.One.description)
+
+        test('one description', () => {
+          expect(message).toContain(oneCommand.description)
         });
-  
-        test('Two command', () => {
-          expect(message).toContain('!Two');
+
+        test('two command', () => {
+          expect(message).toContain('!two');
         });
-  
-        test('Two description', () => {
-          expect(message).toContain(commands.Two.description);
+
+        test('two description', () => {
+          expect(message).toContain(twoCommand.description);
         });
-  
-        test('BlueFish command', () => {
-          expect(message).toContain('!BlueFish');
+
+        test('blueFish command', () => {
+          expect(message).toContain('!blueFish');
         });
-  
+
         test('BlueFish description', () => {
-          expect(message).toContain(commands.BlueFish.description);
+          expect(message).toContain(blueFishCommand.description);
         });
       });
     });

--- a/__tests__/commands/search.test.ts
+++ b/__tests__/commands/search.test.ts
@@ -43,10 +43,24 @@ describe('Search Command', () => {
     await Search.execute(['dingusy'], mockMessage);
     expect(sendMock).lastCalledWith(results.items[0].link);
   });
-  test('Malformed Response', async () => {
-    const mockedData = Promise.resolve({ data: {} });
-    axiosMock.get.mockResolvedValueOnce(mockedData);
-    await Search.execute(['NOPE'], mockMessage);
-    expect(sendMock).lastCalledWith("I'm Sorry Dave, I'm afraid I can't do that...");
+  describe('Malformed Response', () => {
+    let consoleErrorMock: jest.SpyInstance<void, any>;
+    beforeEach(async () => {
+      const mockedData = Promise.resolve({ data: {} });
+      axiosMock.get.mockResolvedValueOnce(mockedData);
+      consoleErrorMock = jest.spyOn(console, 'error')
+        .mockImplementation(() => undefined); // Prevent it from spewing into the test results
+      await Search.execute(['NOPE'], mockMessage);
+    });
+    afterEach(() => {
+      consoleErrorMock.mockRestore();
+    });
+    test('Responds with error message', async () => {
+      expect(sendMock).lastCalledWith("I'm Sorry Dave, I'm afraid I can't do that...");
+    });
+    test('Console logs an error', () => {
+      const errorMessage = "Malformed Google Search Response: {}";
+      expect(consoleErrorMock).lastCalledWith(errorMessage);
+    });
   });
 });

--- a/__tests__/library/commandLoader.test.ts
+++ b/__tests__/library/commandLoader.test.ts
@@ -4,7 +4,8 @@ import config from '../../src/config';
 
 describe('CommandLoader', () => {
   let commandClasses: ICommandClasses;
-  const files = glob.sync(config.commandsPathGlob);
+  const commandsPathGlob = './src/commands/*.ts';
+  const files = glob.sync(commandsPathGlob);
 
   beforeEach(() => {
     commandClasses = CommandLoader.getCommandClasses(files);

--- a/__tests__/library/commandLoader.test.ts
+++ b/__tests__/library/commandLoader.test.ts
@@ -1,5 +1,4 @@
 import glob from 'glob';
-import config from '../../src/config';
 import CommandLoader, { ICommandClasses } from '../../src/library/commandLoader';
 
 describe('CommandLoader', () => {

--- a/__tests__/library/commandLoader.test.ts
+++ b/__tests__/library/commandLoader.test.ts
@@ -1,10 +1,10 @@
 import glob from 'glob';
 import CommandLoader, { ICommandClasses } from '../../src/library/commandLoader';
-import { COMMANDS_PATH_GLOB } from './../../src/library/commands';
+import config from '../../src/config';
 
 describe('CommandLoader', () => {
   let commandClasses: ICommandClasses;
-  const files = glob.sync(COMMANDS_PATH_GLOB);
+  const files = glob.sync(config.commandsPathGlob);
 
   beforeEach(() => {
     commandClasses = CommandLoader.getCommandClasses(files);
@@ -16,6 +16,7 @@ describe('CommandLoader', () => {
     });
   });
 
+  // More of an integration test against real commands
   describe('Class names match their file names', () => {
     test('they match their key name', () => {
       for (let commandName of Object.keys(commandClasses)) {

--- a/__tests__/library/commandLoader.test.ts
+++ b/__tests__/library/commandLoader.test.ts
@@ -1,6 +1,6 @@
 import glob from 'glob';
-import CommandLoader, { ICommandClasses } from '../../src/library/commandLoader';
 import config from '../../src/config';
+import CommandLoader, { ICommandClasses } from '../../src/library/commandLoader';
 
 describe('CommandLoader', () => {
   let commandClasses: ICommandClasses;

--- a/__tests__/library/commands.test.ts
+++ b/__tests__/library/commands.test.ts
@@ -34,7 +34,7 @@ describe('Commands', () => {
 
   test('Can fetch a command', () => {
     const helloCommand = commands.get('hello');
-    expect(helloCommand).toEqual(mockHelloCommand);
+    expect(helloCommand).toBe(mockHelloCommand);
   });
 
   test('Finds the longest name', () => {

--- a/__tests__/library/commands.test.ts
+++ b/__tests__/library/commands.test.ts
@@ -1,6 +1,6 @@
+import { ICommandClasses } from '../../src/library/commandLoader';
 import Commands from '../../src/library/commands';
 import ICommand from '../../src/library/iCommand';
-import { ICommandClasses } from '../../src/library/commandLoader';
 
 describe('Commands', () => {
   let mockHelloCommand: ICommand;
@@ -19,16 +19,16 @@ describe('Commands', () => {
       name: 'YAC',
       description: 'Yet Another Command!',
       execute: jest.fn()
-    }
+    };
     mockCommands = {
       hello: mockHelloCommand,
       yac: mockYetAnotherCommand
-    }
+    };
     commands = new Commands(mockCommands);
   });
 
   test('.names returns command names', () => {
-    const commandNames = ['hello', 'yac']
+    const commandNames = ['hello', 'yac'];
     expect(commands.names).toEqual(commandNames);
   });
 

--- a/__tests__/library/commands.test.ts
+++ b/__tests__/library/commands.test.ts
@@ -1,16 +1,43 @@
 import Commands from '../../src/library/commands';
+import ICommand from '../../src/library/iCommand';
+import { ICommandClasses } from '../../src/library/commandLoader';
 
-// TODO: I feel like this class is too basic to test,
-//  and ultimately a wrapper for other classes that have been tested
-//  Might just remove it some day
 describe('Commands', () => {
-  const commands = new Commands();
-  test('Has a command', () => {
-    expect(Object.keys(commands.all).length).toBeGreaterThan(0);
-    expect(commands.names.length).toBeGreaterThan(0);
+  let mockHelloCommand: ICommand;
+  let mockYetAnotherCommand: ICommand;
+  let mockCommands: ICommandClasses;
+  let commands: Commands;
+
+  beforeEach(() => {
+    // TODO: these should probably go into a factory/mock
+    mockHelloCommand = {
+      name: 'Hello',
+      description: 'Hello World',
+      execute: jest.fn()
+    };
+    mockYetAnotherCommand = {
+      name: 'YAC',
+      description: 'Yet Another Command!',
+      execute: jest.fn()
+    }
+    mockCommands = {
+      hello: mockHelloCommand,
+      yac: mockYetAnotherCommand
+    }
+    commands = new Commands(mockCommands);
   });
+
+  test('.names returns command names', () => {
+    const commandNames = ['hello', 'yac']
+    expect(commands.names).toEqual(commandNames);
+  });
+
   test('Can fetch a command', () => {
-    const first = commands.names[0];
-    expect(commands.get(first)).not.toBeUndefined();
+    const helloCommand = commands.get('hello');
+    expect(helloCommand).toEqual(mockHelloCommand);
+  });
+
+  test('Finds the longest name', () => {
+    expect(commands.longestNameLength()).toEqual(5);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hackbot",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackbot",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Discord bot for the Cascades Tech Club Discord server.",
   "repository": {
     "type": "git",

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -38,7 +38,7 @@ export default Help = class {
       return message += `${config.messagePrefix}${commandName}` +
       // TODO: needs args implemented here after they're part of the magic
         ' '.repeat(amountOfSpaces) +
-        `→ ${command.description}\n`;
+        `  → ${command.description}\n`;
     }, '');
   }
 };

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -13,7 +13,7 @@ export default Help = class {
   }
 
   public static execute(
-    _args: string[],
+    args: string[],
     msg: Message,
     { commands }: { commands: Commands }
   ) {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -20,7 +20,7 @@ export default Help = class {
     const helpMsg = "I am here to help! Well...mostly just make you chuckle at this point, let's be honest.\n\n" +
       "Here is a list of the commands that we've got right now:\n" +
       '```\n' +
-      this.commandsAndDescriptions(commands)+
+      this.commandsAndDescriptions(commands) +
       '```';
 
     msg.reply('sliding into your DMs...');

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -12,26 +12,33 @@ export default Help = class {
     return 'Displays this message';
   }
 
-  public static execute(args: string[], msg: Message) {
-    const commands = new Commands();
-    const longest = commands.longestName();
-
-    let helpMsg = "I am here to help! Well...mostly just make you chuckle at this point, let's be honest.\n\n";
-    helpMsg += "Here is a list of the commands that we've got right now:\n";
-    helpMsg += '```\n';
-
-    commands.names.map((commandName) => {
-      const command = commands.get(commandName);
-      const amountOfSpaces = longest - commandName.length;
-      helpMsg += `${config.messagePrefix}${commandName}`;
-      // TODO: needs args implemented here after they're part of the magic
-      helpMsg += ' '.repeat(amountOfSpaces);
-      helpMsg += `→ ${command.description}\n`;
-    });
-
-    helpMsg += '```';
+  public static execute(
+    _args: string[],
+    msg: Message,
+    { commands }: { commands: Commands }
+  ) {
+    const helpMsg = "I am here to help! Well...mostly just make you chuckle at this point, let's be honest.\n\n" +
+      "Here is a list of the commands that we've got right now:\n" +
+      '```\n' +
+      this.commandsAndDescriptions(commands)+
+      '```';
 
     msg.reply('sliding into your DMs...');
     msg.author.send(helpMsg);
+  }
+
+  private static commandsAndDescriptions(commands: Commands) {
+    const prefixLength = config.messagePrefix.length;
+    const longest = commands.longestNameLength() + prefixLength;
+
+    return commands.names.reduce((message, commandName) => {
+      const command = commands.get(commandName);
+      const commandPrefixLength = commandName.length + prefixLength;
+      const amountOfSpaces = longest - commandPrefixLength;
+      return message += `${config.messagePrefix}${commandName}` +
+      // TODO: needs args implemented here after they're part of the magic
+        ' '.repeat(amountOfSpaces) +
+        `→ ${command.description}\n`;
+    }, '');
   }
 };

--- a/src/commands/purge.ts
+++ b/src/commands/purge.ts
@@ -10,7 +10,11 @@ export default Purge = class {
     return 'Purges the channel it is called within. Restricted to Board Members and Administrators.';
   }
 
-  public static execute(args: string[], msg: Message, bot: Client) {
+  public static execute(
+    _args: string[],
+    msg: Message,
+    { client: bot }: { client: Client }
+  ) {
     const { guild } = msg;
 
     /* global bot */

--- a/src/commands/purge.ts
+++ b/src/commands/purge.ts
@@ -11,7 +11,7 @@ export default Purge = class {
   }
 
   public static execute(
-    _args: string[],
+    args: string[],
     msg: Message,
     { client: bot }: { client: Client }
   ) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,13 +4,11 @@ dotenv.config();
 /* istanbul ignore next */
 // Quite a pain to test for the defaults with dotenv so not worth the effort
 const defaults = {
-  commandsPathGlob: './src/commands/*.ts',
   defaultChannel: process.env.DEFAULT_CHANNEL,
   discordAppToken: process.env.DISCORD_APP_TOKEN,
   env: process.env.NODE_ENV || 'production',
   messagePrefix: process.env.MESSAGE_PREFIX || '!',
   production: process.env.NODE_ENV === 'production',
-  commandTemplateFile: './src/commands/_template.ts',
   get welcomeChannel() { return process.env.WELCOME_CHANNEL || this.defaultChannel; },
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,12 +4,14 @@ dotenv.config();
 /* istanbul ignore next */
 // Quite a pain to test for the defaults with dotenv so not worth the effort
 const defaults = {
+  commandsPathGlob: './src/commands/*.ts',
   defaultChannel: process.env.DEFAULT_CHANNEL,
   discordAppToken: process.env.DISCORD_APP_TOKEN,
   env: process.env.NODE_ENV || 'production',
   messagePrefix: process.env.MESSAGE_PREFIX || '!',
   production: process.env.NODE_ENV === 'production',
-  get welcomeChannel() { return process.env.WELCOME_CHANNEL || this.defaultChannel; }
+  commandTemplateFile: './src/commands/_template.ts',
+  get welcomeChannel() { return process.env.WELCOME_CHANNEL || this.defaultChannel; },
 };
 
 const plugins = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ const defaults = {
   env: process.env.NODE_ENV || 'production',
   messagePrefix: process.env.MESSAGE_PREFIX || '!',
   production: process.env.NODE_ENV === 'production',
-  get welcomeChannel() { return process.env.WELCOME_CHANNEL || this.defaultChannel; },
+  get welcomeChannel() { return process.env.WELCOME_CHANNEL || this.defaultChannel; }
 };
 
 const plugins = {

--- a/src/library/commandLoader.ts
+++ b/src/library/commandLoader.ts
@@ -26,6 +26,7 @@ export default class CommandLoader {
   }
 
   private static removeTemplateFile(files: string[]) {
-    return files.filter(file => file !== config.commandTemplateFile);
+    const commandTemplateFile = './src/commands/_template.ts';
+    return files.filter(file => file !== commandTemplateFile);
   }
 }

--- a/src/library/commandLoader.ts
+++ b/src/library/commandLoader.ts
@@ -1,7 +1,6 @@
 import camelCase from 'lodash.camelcase';
 import path from 'path';
 import Command from './iCommand';
-import config from '../config';
 
 export interface ICommandClasses { [key: string]: Command; }
 

--- a/src/library/commandLoader.ts
+++ b/src/library/commandLoader.ts
@@ -1,6 +1,7 @@
 import camelCase from 'lodash.camelcase';
 import path from 'path';
 import Command from './iCommand';
+import config from '../config';
 
 export interface ICommandClasses { [key: string]: Command; }
 
@@ -25,6 +26,6 @@ export default class CommandLoader {
   }
 
   private static removeTemplateFile(files: string[]) {
-    return files.filter(file => file !== './src/commands/_template.ts');
+    return files.filter(file => file !== config.commandTemplateFile);
   }
 }

--- a/src/library/commands.ts
+++ b/src/library/commands.ts
@@ -1,22 +1,15 @@
-import glob from 'glob';
-import config from '../config';
-import CommandLoader, { ICommandClasses } from './commandLoader';
+import { ICommandClasses } from './commandLoader';
 import Command from './iCommand';
-
-export const COMMANDS_PATH_GLOB = './src/commands/*.ts';
 
 // TODO: debateable whether we even need this wrapper class
 /**
  * @class Commands
  */
 export default class Commands {
-
   public readonly all: ICommandClasses;
-  private commandFiles: string[];
 
-  constructor() {
-    this.commandFiles = glob.sync(COMMANDS_PATH_GLOB);
-    this.all = CommandLoader.getCommandClasses(this.commandFiles);
+  constructor(commandClasses: ICommandClasses) {
+    this.all = commandClasses;
   }
 
   get names() {
@@ -27,15 +20,10 @@ export default class Commands {
     return this.all[commandName];
   }
 
-  public longestName() {
+  public longestNameLength() {
     // Find the longest synopsis
-    return this.names.reduce((max, commandName) => {
-      commandName = `${config.messagePrefix}${commandName}`;
-      if (commandName.length + 1 > max) {
-        max = commandName.length + 1;
-      }
-      return max;
-    }, 0);
+    const longest = this.names.sort((a, b) => b.length - a.length)[0];
+    return longest.length;
   }
 
 }

--- a/src/library/core.ts
+++ b/src/library/core.ts
@@ -1,11 +1,15 @@
-
+import glob from 'glob';
 import { Client, GuildMember, Message, TextChannel } from 'discord.js';
 import config from '../config';
+import CommandLoader from './commandLoader';
 import CommandParser from './commandParser';
 import Commands from './commands';
 
 const cmdParser = new CommandParser(config.messagePrefix);
-const commands = new Commands();
+
+const commandFiles = glob.sync(config.commandsPathGlob);
+const commandClasses = CommandLoader.getCommandClasses(commandFiles);
+const commands = new Commands(commandClasses);
 
 export default class Core {
 
@@ -32,7 +36,10 @@ export default class Core {
     try {
       const command = commands.get(commandName);
       if (command) {
-        return command.execute(args, msg, this.client);
+        return command.execute(args, msg, {
+          client: this.client,
+          commands
+        });
       }
       else {
         return channel.send(`Command not found: ${commandName}`);

--- a/src/library/core.ts
+++ b/src/library/core.ts
@@ -1,5 +1,5 @@
-import glob from 'glob';
 import { Client, GuildMember, Message, TextChannel } from 'discord.js';
+import glob from 'glob';
 import config from '../config';
 import CommandLoader from './commandLoader';
 import CommandParser from './commandParser';

--- a/src/library/core.ts
+++ b/src/library/core.ts
@@ -6,8 +6,8 @@ import CommandParser from './commandParser';
 import Commands from './commands';
 
 const cmdParser = new CommandParser(config.messagePrefix);
-
-const commandFiles = glob.sync(config.commandsPathGlob);
+const commandsPathGlob = './src/commands/*.ts';
+const commandFiles = glob.sync(commandsPathGlob);
 const commandClasses = CommandLoader.getCommandClasses(commandFiles);
 const commands = new Commands(commandClasses);
 

--- a/src/library/iCommand.ts
+++ b/src/library/iCommand.ts
@@ -10,7 +10,7 @@ import Commands from "./commands";
 export default interface ICommand {
   readonly name: string;
   readonly description: string;
-  execute(args: string[], msg: Message, extra?:{
+  execute(args: string[], msg: Message, extra?: {
     client?: Client,
     commands?: Commands
   }): void;

--- a/src/library/iCommand.ts
+++ b/src/library/iCommand.ts
@@ -1,4 +1,5 @@
 import { Client, Message } from "discord.js";
+import Commands from "./commands";
 
 /**
  * An interface for all commands to extend, representing the API that all
@@ -9,5 +10,8 @@ import { Client, Message } from "discord.js";
 export default interface ICommand {
   readonly name: string;
   readonly description: string;
-  execute(args: string[], msg: Message, client?: Client): void;
+  execute(args: string[], msg: Message, extra?:{
+    client?: Client,
+    commands?: Commands
+  }): void;
 }


### PR DESCRIPTION
## Changes
- Add tests for Help command
- Refactor Help command
  - Easier to read
  - Split out some meat into a new method.
- Mute and test console error logging from Search command
- Change library/command to use Dependency Injection™
  - Better tests, better pizza, Papa Yongs
- Add additional tests to library/command
- Core now pushes a 3rd parameter that Command can optionally use. The 3rd parameter provides the client and the loaded commands.
  - Help command can now utilize the already loaded commands without instantiating a new instance.
    - More Dependency Injection.

## Related Issues
- #31 