### PR TITLE
112 fix deprecation warning text channel send message

### DIFF
--- a/__tests__/commands/version.test.ts
+++ b/__tests__/commands/version.test.ts
@@ -6,7 +6,6 @@ let sendMock: MockedMessage;
 beforeEach(() => {
   sendMock = jest.fn();
   mockMessage.channel.send = sendMock;
-  mockMessage.channel.sendMessage = sendMock;
 });
 
 describe('Version Command', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackbot",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Discord bot for the Cascades Tech Club Discord server.",
   "repository": {
     "type": "git",

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -13,7 +13,7 @@ export default Version = class {
   }
 
   public static execute(args: string[], msg: Message) {
-    return msg.channel.sendMessage(`Hackbot ${config.env} is running v${version}`);
+    return msg.channel.send(`Hackbot ${config.env} is running v${version}`);
   }
 
 };


### PR DESCRIPTION
Fixes #112 changes `sendMessage` to `send`
Hoping this will allow us to update the discordjs version smoothly ;) 