### PR TITLE
Alias Imports

### DIFF
--- a/__tests__/commands/add.test.ts
+++ b/__tests__/commands/add.test.ts
@@ -1,4 +1,4 @@
-import Add from '../../src/commands/add';
+import Add from '@/commands/add';
 import { message as mockMessage, MockedMessage } from '../mocks/discord';
 
 let sendMock: MockedMessage;

--- a/__tests__/commands/format.test.ts
+++ b/__tests__/commands/format.test.ts
@@ -1,4 +1,4 @@
-import Format from '../../src/commands/format';
+import Format from '@/commands/format';
 
 import { message as mockMessage, MockedMessage } from '../mocks/discord';
 

--- a/__tests__/commands/gitProfile.test.ts
+++ b/__tests__/commands/gitProfile.test.ts
@@ -1,4 +1,4 @@
-import GitProfile from '../../src/commands/gitProfile';
+import GitProfile from '@/commands/gitProfile';
 import axiosMock from '../__mocks__/axios';
 import mockGithubProfile from '../mockData/githubProfile';
 import { message as mockMessage, MockedMessage } from '../mocks/discord';

--- a/__tests__/commands/help.test.ts
+++ b/__tests__/commands/help.test.ts
@@ -1,5 +1,5 @@
-import Help from '../../src/commands/help';
-import Commands from '../../src/library/commands';
+import Help from '@/commands/help';
+import Commands from '@/library/commands';
 import { message as mockMessage, MockedMessage } from '../mocks/discord';
 
 // TODO: These should be in a factory/mock

--- a/__tests__/commands/lmgtfy.test.ts
+++ b/__tests__/commands/lmgtfy.test.ts
@@ -1,4 +1,4 @@
-import Lmgtfy from '../../src/commands/lmgtfy';
+import Lmgtfy from '@/commands/lmgtfy';
 import { message as mockMessage, MockedMessage } from '../mocks/discord';
 
 let sendMock: MockedMessage;

--- a/__tests__/commands/magic8ball.test.ts
+++ b/__tests__/commands/magic8ball.test.ts
@@ -1,4 +1,4 @@
-import Magic8Ball from '../../src/commands/magic8ball';
+import Magic8Ball from '@/commands/magic8ball';
 import { message as mockMessage, MockedMessage } from '../mocks/discord';
 
 let sendMock: MockedMessage;

--- a/__tests__/commands/rules.test.ts
+++ b/__tests__/commands/rules.test.ts
@@ -1,4 +1,4 @@
-import Rules from '../../src/commands/rules';
+import Rules from '@/commands/rules';
 
 import { message as mockMessage, MockedMessage } from '../mocks/discord';
 

--- a/__tests__/commands/say.test.ts
+++ b/__tests__/commands/say.test.ts
@@ -1,4 +1,4 @@
-import Say from '../../src/commands/say';
+import Say from '@/commands/say';
 
 import { message as mockMessage, MockedMessage } from '../mocks/discord';
 

--- a/__tests__/commands/search.test.ts
+++ b/__tests__/commands/search.test.ts
@@ -1,11 +1,11 @@
-import Search from '../../src/commands/search';
-import config from '../../src/config';
+import Search from '@/commands/search';
+import config from '@/config';
 import axiosMock from '../__mocks__/axios';
 import { message as mockMessage, MockedMessage } from '../mocks/discord';
 import { noResults, results } from './../mockData/search';
 
 jest.mock('axios');
-jest.mock('../../src/config.ts');
+jest.mock('@/config.ts');
 
 let sendMock: MockedMessage;
 beforeEach(() => {

--- a/__tests__/commands/source.test.ts
+++ b/__tests__/commands/source.test.ts
@@ -1,5 +1,5 @@
 import { message as mockMessage, MockedMessage } from '../mocks/discord';
-import Source from './../../src/commands/source';
+import Source from '@/commands/source';
 
 let sendMock: MockedMessage;
 beforeEach(() => {

--- a/__tests__/commands/version.test.ts
+++ b/__tests__/commands/version.test.ts
@@ -1,6 +1,6 @@
 import { Message } from 'discord.js';
 import { message as mockMessage, MockedMessage } from '../mocks/discord';
-import Version from './../../src/commands/version';
+import Version from '@/commands/version';
 
 let sendMock: MockedMessage;
 beforeEach(() => {

--- a/__tests__/commands/xmas.test.ts
+++ b/__tests__/commands/xmas.test.ts
@@ -1,4 +1,4 @@
-import Xmas from '../../src/commands/xmas';
+import Xmas from '@/commands/xmas';
 import { message as mockMessage, MockedMessage } from '../mocks/discord';
 
 let sendMock: MockedMessage;

--- a/__tests__/library/commandLoader.test.ts
+++ b/__tests__/library/commandLoader.test.ts
@@ -1,5 +1,5 @@
 import glob from 'glob';
-import CommandLoader, { ICommandClasses } from '../../src/library/commandLoader';
+import CommandLoader, { ICommandClasses } from '@/library/commandLoader';
 
 describe('CommandLoader', () => {
   let commandClasses: ICommandClasses;

--- a/__tests__/library/commandParser.test.ts
+++ b/__tests__/library/commandParser.test.ts
@@ -1,4 +1,4 @@
-import CommandParser from '../../src/library/commandParser';
+import CommandParser from '@/library/commandParser';
 
 describe('CommandParser', () => {
   const messagePrefix = 'FAKE';

--- a/__tests__/library/commands.test.ts
+++ b/__tests__/library/commands.test.ts
@@ -1,6 +1,6 @@
-import { ICommandClasses } from '../../src/library/commandLoader';
-import Commands from '../../src/library/commands';
-import ICommand from '../../src/library/iCommand';
+import { ICommandClasses } from '@/library/commandLoader';
+import Commands from '@/library/commands';
+import ICommand from '@/library/interfaces/iCommand';
 
 describe('Commands', () => {
   let mockHelloCommand: ICommand;

--- a/__tests__/mockData/githubProfile.ts
+++ b/__tests__/mockData/githubProfile.ts
@@ -1,4 +1,4 @@
-import IGithubProfile from "../../src/commands/interfaces/iGithubProfile";
+import IGithubProfile from '@/commands/interfaces/iGithubProfile';
 
 export default {
   login: "ctsstc",

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,5 +12,8 @@ module.exports = {
     "jsx",
     "json",
     "node"
-  ]
+  ],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  }
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
     "node"
   ],
   moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1'
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '@root/(.*)$': '<rootDir>/$1'
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hackbot",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -736,6 +736,12 @@
         "jest-diff": "^25.2.1",
         "pretty-format": "^25.2.1"
       }
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
     },
     "@types/lodash": {
       "version": "4.14.150",
@@ -4595,6 +4601,35 @@
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.17",
         "yn": "3.1.1"
+      }
+    },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
       }
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "hackbot.js",
   "scripts": {
-    "start": "ts-node src/index.ts",
+    "start": "ts-node -r tsconfig-paths/register src/index.ts",
     "start:dev": "ts-node src/index.ts --type-check",
     "bs": "npm run build && npm start",
     "watch": "nodemon build/hackbot.js",
@@ -43,6 +43,7 @@
   "devDependencies": {
     "jest": "^25.1.0",
     "ts-jest": "^25.1.0",
+    "tsconfig-paths": "^3.9.0",
     "tslint": "^5.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hackbot",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Discord bot for the Cascades Tech Club Discord server.",
   "repository": {
     "type": "git",

--- a/src/commands/_template.ts
+++ b/src/commands/_template.ts
@@ -1,5 +1,5 @@
+import ICommand from '@/library/interfaces/iCommand';
 import { Message } from 'discord.js';
-import ICommand from '../library/interfaces/iCommand';
 
 // Hack for implementing with static properties/methods
 let CommandName: ICommand;

--- a/src/commands/_template.ts
+++ b/src/commands/_template.ts
@@ -1,5 +1,5 @@
 import { Message } from 'discord.js';
-import ICommand from '../library/iCommand';
+import ICommand from '../library/interfaces/iCommand';
 
 // Hack for implementing with static properties/methods
 let CommandName: ICommand;

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,5 +1,5 @@
 import { Message } from "discord.js";
-import ICommand from "../library/iCommand";
+import ICommand from "../library/interfaces/iCommand";
 
 let Add: ICommand;
 

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,5 +1,5 @@
 import { Message } from "discord.js";
-import ICommand from "../library/interfaces/iCommand";
+import ICommand from "@/library/interfaces/iCommand";
 
 let Add: ICommand;
 

--- a/src/commands/format.ts
+++ b/src/commands/format.ts
@@ -1,5 +1,5 @@
 import { Message } from 'discord.js';
-import ICommand from '../library/interfaces/iCommand';
+import ICommand from '@/library/interfaces/iCommand';
 
 // Hack for implementing with static properties/methods
 let Format: ICommand;

--- a/src/commands/format.ts
+++ b/src/commands/format.ts
@@ -1,5 +1,5 @@
 import { Message } from 'discord.js';
-import ICommand from '../library/iCommand';
+import ICommand from '../library/interfaces/iCommand';
 
 // Hack for implementing with static properties/methods
 let Format: ICommand;

--- a/src/commands/gitProfile.ts
+++ b/src/commands/gitProfile.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { Message } from 'discord.js';
 import moment from 'moment';
-import ICommand from '../library/iCommand';
+import ICommand from '../library/interfaces/iCommand';
 import IGithubProfile from './interfaces/iGithubProfile';
 
 let GitProfile: ICommand;

--- a/src/commands/gitProfile.ts
+++ b/src/commands/gitProfile.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { Message } from 'discord.js';
 import moment from 'moment';
-import ICommand from '../library/interfaces/iCommand';
+import ICommand from '@/library/interfaces/iCommand';
 import IGithubProfile from './interfaces/iGithubProfile';
 
 let GitProfile: ICommand;

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,7 +1,7 @@
 import { Message } from 'discord.js';
-import config from '../config';
-import Commands from '../library/commands';
-import ICommand from '../library/interfaces/iCommand';
+import config from '@/config';
+import Commands from '@/library/commands';
+import ICommand from '@/library/interfaces/iCommand';
 
 let Help: ICommand;
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,7 +1,7 @@
 import { Message } from 'discord.js';
 import config from '../config';
 import Commands from '../library/commands';
-import ICommand from '../library/iCommand';
+import ICommand from '../library/interfaces/iCommand';
 
 let Help: ICommand;
 

--- a/src/commands/lmgtfy.ts
+++ b/src/commands/lmgtfy.ts
@@ -1,5 +1,5 @@
 import { Message } from 'discord.js';
-import ICommand from '../library/iCommand';
+import ICommand from '../library/interfaces/iCommand';
 
 let Lmgtfy: ICommand;
 

--- a/src/commands/lmgtfy.ts
+++ b/src/commands/lmgtfy.ts
@@ -1,5 +1,5 @@
 import { Message } from 'discord.js';
-import ICommand from '../library/interfaces/iCommand';
+import ICommand from '@/library/interfaces/iCommand';
 
 let Lmgtfy: ICommand;
 

--- a/src/commands/magic8ball.ts
+++ b/src/commands/magic8ball.ts
@@ -1,5 +1,5 @@
 import { Message } from 'discord.js';
-import ICommand from '../library/iCommand';
+import ICommand from '../library/interfaces/iCommand';
 
 let Magic8Ball: ICommand;
 

--- a/src/commands/magic8ball.ts
+++ b/src/commands/magic8ball.ts
@@ -1,5 +1,5 @@
 import { Message } from 'discord.js';
-import ICommand from '../library/interfaces/iCommand';
+import ICommand from '@/library/interfaces/iCommand';
 
 let Magic8Ball: ICommand;
 

--- a/src/commands/purge.ts
+++ b/src/commands/purge.ts
@@ -1,4 +1,4 @@
-import ICommand from '@/library/iCommand';
+import ICommand from '@/library/interfaces/iCommand';
 import { Client, DMChannel, Message } from 'discord.js';
 
 let Purge: ICommand;

--- a/src/commands/purge.ts
+++ b/src/commands/purge.ts
@@ -1,5 +1,5 @@
+import ICommand from '@/library/iCommand';
 import { Client, DMChannel, Message } from 'discord.js';
-import ICommand from '../library/interfaces/iCommand';
 
 let Purge: ICommand;
 

--- a/src/commands/purge.ts
+++ b/src/commands/purge.ts
@@ -1,5 +1,5 @@
 import { Client, DMChannel, Message } from 'discord.js';
-import ICommand from '../library/iCommand';
+import ICommand from '../library/interfaces/iCommand';
 
 let Purge: ICommand;
 

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -1,5 +1,5 @@
 import { Message } from 'discord.js';
-import ICommand from '../library/interfaces/iCommand';
+import ICommand from '@/library/interfaces/iCommand';
 
 let Rules: ICommand;
 

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -1,5 +1,5 @@
 import { Message } from 'discord.js';
-import ICommand from '../library/iCommand';
+import ICommand from '../library/interfaces/iCommand';
 
 let Rules: ICommand;
 

--- a/src/commands/say.ts
+++ b/src/commands/say.ts
@@ -1,5 +1,5 @@
 import { Message } from 'discord.js';
-import ICommand from '../library/interfaces/iCommand';
+import ICommand from '@/library/interfaces/iCommand';
 
 let Say: ICommand;
 

--- a/src/commands/say.ts
+++ b/src/commands/say.ts
@@ -1,5 +1,5 @@
 import { Message } from 'discord.js';
-import ICommand from '../library/iCommand';
+import ICommand from '../library/interfaces/iCommand';
 
 let Say: ICommand;
 

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,7 +1,7 @@
+import config from '@/config';
+import ICommand from '@/library/interfaces/iCommand';
 import axios, { AxiosResponse } from 'axios';
 import { Message } from 'discord.js';
-import config from '../config';
-import ICommand from '../library/interfaces/iCommand';
 
 let Search: ICommand;
 

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosResponse } from 'axios';
 import { Message } from 'discord.js';
 import config from '../config';
-import ICommand from '../library/iCommand';
+import ICommand from '../library/interfaces/iCommand';
 
 let Search: ICommand;
 

--- a/src/commands/source.ts
+++ b/src/commands/source.ts
@@ -1,5 +1,5 @@
 import { Message } from 'discord.js';
-import ICommand from '../library/iCommand';
+import ICommand from '../library/interfaces/iCommand';
 
 let Source: ICommand;
 

--- a/src/commands/source.ts
+++ b/src/commands/source.ts
@@ -1,5 +1,5 @@
 import { Message } from 'discord.js';
-import ICommand from '../library/interfaces/iCommand';
+import ICommand from '@/library/interfaces/iCommand';
 
 let Source: ICommand;
 

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,7 +1,7 @@
+import config from '@/config';
+import { version } from '@root/package.json';
 import { Message } from 'discord.js';
-import { version } from '../../package.json';
-import config from '../config';
-import ICommand from '../library/interfaces/iCommand';
+import ICommand from '@/library/interfaces/iCommand';
 
 let Version: ICommand;
 

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,7 +1,7 @@
 import { Message } from 'discord.js';
 import { version } from '../../package.json';
 import config from '../config';
-import ICommand from '../library/iCommand';
+import ICommand from '../library/interfaces/iCommand';
 
 let Version: ICommand;
 

--- a/src/commands/weather.ts
+++ b/src/commands/weather.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosResponse } from 'axios';
 import { Message } from 'discord.js';
 import config from '../config';
-import ICommand from '../library/iCommand';
+import ICommand from '../library/interfaces/iCommand';
 
 let Weather: ICommand;
 

--- a/src/commands/weather.ts
+++ b/src/commands/weather.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosResponse } from 'axios';
 import { Message } from 'discord.js';
-import config from '../config';
-import ICommand from '../library/interfaces/iCommand';
+import config from '@/config';
+import ICommand from '@/library/interfaces/iCommand';
 
 let Weather: ICommand;
 

--- a/src/commands/xmas.ts
+++ b/src/commands/xmas.ts
@@ -1,5 +1,5 @@
 import { Message } from 'discord.js';
-import ICommand from '../library/interfaces/iCommand';
+import ICommand from '@/library/interfaces/iCommand';
 
 let Xmas: ICommand;
 

--- a/src/commands/xmas.ts
+++ b/src/commands/xmas.ts
@@ -1,5 +1,5 @@
 import { Message } from 'discord.js';
-import ICommand from '../library/iCommand';
+import ICommand from '../library/interfaces/iCommand';
 
 let Xmas: ICommand;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
+import config from '@/config';
+import Core from '@/library/core';
 import { Client } from 'discord.js';
-import config from './config';
-import Core from './library/core';
 
 const client = new Client();
 const core = new Core(client);

--- a/src/library/commandLoader.ts
+++ b/src/library/commandLoader.ts
@@ -1,6 +1,6 @@
 import camelCase from 'lodash.camelcase';
 import path from 'path';
-import Command from './iCommand';
+import Command from './interfaces/iCommand';
 
 export interface ICommandClasses { [key: string]: Command; }
 

--- a/src/library/commands.ts
+++ b/src/library/commands.ts
@@ -1,5 +1,5 @@
 import { ICommandClasses } from './commandLoader';
-import Command from './iCommand';
+import Command from './interfaces/iCommand';
 
 // TODO: debateable whether we even need this wrapper class
 /**

--- a/src/library/core.ts
+++ b/src/library/core.ts
@@ -1,6 +1,6 @@
+import config from '@/config';
 import { Client, GuildMember, Message, TextChannel } from 'discord.js';
 import glob from 'glob';
-import config from '../config';
 import CommandLoader from './commandLoader';
 import CommandParser from './commandParser';
 import Commands from './commands';

--- a/src/library/interfaces/iCommand.ts
+++ b/src/library/interfaces/iCommand.ts
@@ -1,5 +1,5 @@
 import { Client, Message } from "discord.js";
-import Commands from "./commands";
+import Commands from "../commands";
 
 /**
  * An interface for all commands to extend, representing the API that all

--- a/src/library/interfaces/iCommand.ts
+++ b/src/library/interfaces/iCommand.ts
@@ -1,5 +1,5 @@
 import { Client, Message } from "discord.js";
-import Commands from "../commands";
+import Commands from "@/commands";
 
 /**
  * An interface for all commands to extend, representing the API that all

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "sourceMap": true,                        /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./build",                      /* Redirect output structure to the directory. */
-    "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
@@ -36,10 +36,12 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "baseUrl": ".",                           /* Base directory to resolve non-absolute module names. */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "baseUrl": "./src",                           /* Base directory to resolve non-absolute module names. */
     "paths": {
-      "*": ["typings/*"]
+      "@/*": [
+        "./*"
+      ]
     },                                        /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     "typeRoots": [
@@ -61,7 +63,11 @@
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
+  "include": [
+    "src/**/*.ts",
+    "__tests__/**/*.ts"
+  ],
   "exclude": [
-    "**/*.test.ts"
+    "node_modules"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,9 @@
     "paths": {
       "@/*": [
         "./*"
+      ],
+      "@root/*": [
+        "../*"
       ]
     },                                        /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
## Changes
- Import using an absolute pathed alias
- You can now use `@` to reference the `/src` directory
- Instead of nasty relative imports now you can use `@` as an alias to the src directory
- Tests will use the alias
- Node TS will compile and run using aliases as well
- VSCode IDE recognizes the pathing based off of the tsconfig 🎉 

## Fixes
- Fixes #119 

## Notes
- Branch name is completely misnamed :P 
- Version bump: `2.2.0`