### PR TITLE
Create LanguageRunner system and a command to execute user code

### DIFF
--- a/__tests__/__mocks__/axios.ts
+++ b/__tests__/__mocks__/axios.ts
@@ -4,5 +4,8 @@ export default {
   }),
   request: jest.fn().mockResolvedValue({
     data: {}
-  })
+  }),
+  post: jest.fn().mockResolvedValue({
+    data: {}
+  }),
 };

--- a/__tests__/commands/run.test.ts
+++ b/__tests__/commands/run.test.ts
@@ -1,0 +1,21 @@
+import Run from '@/commands/run';
+import { message as mockMessage, MockedMessage } from '../mocks/discord';
+
+let sendMock: MockedMessage;
+beforeEach(() => {
+    sendMock = jest.fn();
+    mockMessage.channel.send = sendMock;
+    mockMessage.reply = sendMock;
+});
+
+test('Malformed message', () => {
+    mockMessage.content = "Wow this is nowhere near the correct content";
+    Run.execute([], mockMessage);
+    expect(sendMock).lastCalledWith("Sorry, I ran into some problems understanding your message. Here is the error stopping me.\nError: Unable to extract code from Wow this is nowhere near the correct content");
+});
+
+test('Unknown language', () => {
+    mockMessage.content = "```invalidLanguage\nblahblahblah```";
+    Run.execute([], mockMessage);
+    expect(sendMock).lastCalledWith("Unknown language: invalidLanguage")
+});

--- a/__tests__/commands/source.test.ts
+++ b/__tests__/commands/source.test.ts
@@ -1,5 +1,5 @@
-import { message as mockMessage, MockedMessage } from '../mocks/discord';
 import Source from '@/commands/source';
+import { message as mockMessage, MockedMessage } from '../mocks/discord';
 
 let sendMock: MockedMessage;
 beforeEach(() => {

--- a/__tests__/commands/version.test.ts
+++ b/__tests__/commands/version.test.ts
@@ -1,6 +1,6 @@
+import Version from '@/commands/version';
 import { Message } from 'discord.js';
 import { message as mockMessage, MockedMessage } from '../mocks/discord';
-import Version from '@/commands/version';
 
 let sendMock: MockedMessage;
 beforeEach(() => {

--- a/__tests__/languages/rust.test.ts
+++ b/__tests__/languages/rust.test.ts
@@ -1,0 +1,21 @@
+import Rust from '@/runners/rust';
+import axiosMock from '../__mocks__/axios';
+
+jest.mock('axios');
+
+test('valid code', async () => {
+    const code = "testCode";
+    let mockResponse = Promise.resolve({ data: { success: true, stdout: "test", stderr: "   Compiling playground v0.0.1 (/playground)\n    Finished dev [unoptimized + debuginfo] target(s) in 0.43s\n     Running `target/debug/playground`\n" } });
+    axiosMock.post.mockResolvedValueOnce(mockResponse);
+    let result = await Rust.execute(code);
+    expect(result).toEqual({ success: true, output: "test" });
+})
+
+test('invalid code', async () => {
+    const code = "testCode";
+    const errorResult = "bad code";
+    let mockResponse = Promise.resolve({ data: { success: false, stdout: "", stderr: errorResult } });
+    axiosMock.post.mockResolvedValueOnce(mockResponse);
+    let result = await Rust.execute(code);
+    expect(result).toEqual({ success: false, output: errorResult });
+})

--- a/__tests__/library/commandLoader.test.ts
+++ b/__tests__/library/commandLoader.test.ts
@@ -1,5 +1,5 @@
-import glob from 'glob';
 import CommandLoader, { ICommandClasses } from '@/library/commandLoader';
+import glob from 'glob';
 
 describe('CommandLoader', () => {
   let commandClasses: ICommandClasses;

--- a/__tests__/library/languages.test.ts
+++ b/__tests__/library/languages.test.ts
@@ -1,0 +1,31 @@
+import Languages from '@/library/languages';
+import IRunner from '@/library/interfaces/iRunner';
+import { ILanguageRunners } from '@/library/languageLoader';
+
+describe('Languages', () => {
+    let mockLanguageRunner: IRunner;
+    let languageRunners: ILanguageRunners;
+    let languages: Languages;
+
+    beforeEach(() => {
+        mockLanguageRunner = {
+            execute: jest.fn()
+        };
+
+        languageRunners = {
+            testLang: mockLanguageRunner,
+        };
+
+        languages = new Languages(languageRunners);
+    });
+
+    test('.names returns language names', () => {
+        const languageNames = ['testLang'];
+        expect(languages.names).toEqual(languageNames);
+    });
+
+    test('Can fetch a command', () => {
+        const testLang = languages.get('testLang');
+        expect(testLang).toBe(mockLanguageRunner);
+    });
+})

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,5 +1,5 @@
-import { Message } from "discord.js";
 import ICommand from "@/library/interfaces/iCommand";
+import { Message } from "discord.js";
 
 let Add: ICommand;
 

--- a/src/commands/format.ts
+++ b/src/commands/format.ts
@@ -1,5 +1,5 @@
-import { Message } from 'discord.js';
 import ICommand from '@/library/interfaces/iCommand';
+import { Message } from 'discord.js';
 
 // Hack for implementing with static properties/methods
 let Format: ICommand;

--- a/src/commands/gitProfile.ts
+++ b/src/commands/gitProfile.ts
@@ -1,7 +1,7 @@
+import ICommand from '@/library/interfaces/iCommand';
 import axios from 'axios';
 import { Message } from 'discord.js';
 import moment from 'moment';
-import ICommand from '@/library/interfaces/iCommand';
 import IGithubProfile from './interfaces/iGithubProfile';
 
 let GitProfile: ICommand;

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,7 +1,7 @@
-import { Message } from 'discord.js';
 import config from '@/config';
 import Commands from '@/library/commands';
 import ICommand from '@/library/interfaces/iCommand';
+import { Message } from 'discord.js';
 
 let Help: ICommand;
 

--- a/src/commands/lmgtfy.ts
+++ b/src/commands/lmgtfy.ts
@@ -1,5 +1,5 @@
-import { Message } from 'discord.js';
 import ICommand from '@/library/interfaces/iCommand';
+import { Message } from 'discord.js';
 
 let Lmgtfy: ICommand;
 

--- a/src/commands/magic8ball.ts
+++ b/src/commands/magic8ball.ts
@@ -1,5 +1,5 @@
-import { Message } from 'discord.js';
 import ICommand from '@/library/interfaces/iCommand';
+import { Message } from 'discord.js';
 
 let Magic8Ball: ICommand;
 

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -1,5 +1,5 @@
-import { Message } from 'discord.js';
 import ICommand from '@/library/interfaces/iCommand';
+import { Message } from 'discord.js';
 
 let Rules: ICommand;
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,0 +1,60 @@
+import ICommand from '@/library/interfaces/iCommand';
+import { Message } from 'discord.js';
+import axios, { AxiosResponse } from 'axios';
+import { parse } from 'querystring';
+import Languages from '@/library/languages';
+
+
+// Hack for implementing with static properties/methods
+let CodeRunner: ICommand;
+export default CodeRunner = class {
+
+  /* istanbul ignore next */
+  static get description(): string {
+    return 'Executes provided code using a LanguageRunner';
+  }
+
+  public static execute(args: string[], msg: Message, extra: {
+    languages: Languages
+  }) {
+
+    let parseResponse;
+
+    try {
+      parseResponse = this.parseCode(msg.content);
+      if(!extra.languages.get(parseResponse.language)) {
+        msg.channel.send(`Unknown language: ${parseResponse.language}`);
+        return;
+      }
+    } catch {
+      msg.channel.send("Sorry, I wasn't able to understand your formatting. Please try again.");
+      return;
+    }
+    
+
+    let codeRunnerResponse = extra.languages.get(parseResponse.language).execute(parseResponse.code);
+
+    codeRunnerResponse.then(response => {
+      if (response.success) {
+        msg.channel.send("```" + response.output + "```");
+      } else {
+        msg.channel.send("Unfortunately I was unable to run your code. Here is the error I received.\n```" + response.output + "```");
+      }
+    })
+
+  }
+
+  //Tries to pull language and source code out of message
+  private static parseCode(messageText: string): { language: string, code: string } {
+    let codeRegex = /(```(.[^\n]*))(\n(.*))(```)/s;
+    let match = codeRegex.exec(messageText);
+
+    //Group 2 = language, group 4 = code
+    if (match && match[2] && match[4]) {
+      return { language: match[2], code: match[4] };
+    } else {
+      throw new Error(`Unable to extract code from ${messageText}`)
+    }
+  }
+
+};

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -7,6 +7,7 @@ const languages = new Languages();
 // Hack for implementing with static properties/methods
 let Run: ICommand;
 export default Run = class {
+  
 
   /* istanbul ignore next */
   static get description(): string {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -5,8 +5,8 @@ import { Message } from 'discord.js';
 import { parse } from 'querystring';
 
 // Hack for implementing with static properties/methods
-let CodeRunner: ICommand;
-export default CodeRunner = class {
+let Run: ICommand;
+export default Run = class {
 
   /* istanbul ignore next */
   static get description(): string {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -7,7 +7,7 @@ const languages = new Languages();
 // Hack for implementing with static properties/methods
 let Run: ICommand;
 export default Run = class {
-  
+
 
   /* istanbul ignore next */
   static get description(): string {
@@ -24,8 +24,8 @@ export default Run = class {
         msg.channel.send(`Unknown language: ${parseResponse.language}`);
         return;
       }
-    } catch {
-      msg.channel.send("Sorry, I wasn't able to understand your formatting. Please try again.");
+    } catch (e) {
+      msg.channel.send("Sorry, I ran into some problems understanding your message. Here is the error stopping me.\n" + e);
       return;
     }
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,8 +1,6 @@
 import ICommand from '@/library/interfaces/iCommand';
 import Languages from '@/library/languages';
-import axios, { AxiosResponse } from 'axios';
 import { Message } from 'discord.js';
-import { parse } from 'querystring';
 
 const languages = new Languages();
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,9 +1,8 @@
 import ICommand from '@/library/interfaces/iCommand';
-import { Message } from 'discord.js';
-import axios, { AxiosResponse } from 'axios';
-import { parse } from 'querystring';
 import Languages from '@/library/languages';
-
+import axios, { AxiosResponse } from 'axios';
+import { Message } from 'discord.js';
+import { parse } from 'querystring';
 
 // Hack for implementing with static properties/methods
 let CodeRunner: ICommand;
@@ -22,7 +21,7 @@ export default CodeRunner = class {
 
     try {
       parseResponse = this.parseCode(msg.content);
-      if(!extra.languages.get(parseResponse.language)) {
+      if (!extra.languages.get(parseResponse.language)) {
         msg.channel.send(`Unknown language: ${parseResponse.language}`);
         return;
       }
@@ -30,30 +29,33 @@ export default CodeRunner = class {
       msg.channel.send("Sorry, I wasn't able to understand your formatting. Please try again.");
       return;
     }
-    
 
-    let codeRunnerResponse = extra.languages.get(parseResponse.language).execute(parseResponse.code);
+    const codeRunnerResponse = extra.languages.get(parseResponse.language).execute(parseResponse.code);
 
     codeRunnerResponse.then(response => {
       if (response.success) {
         msg.channel.send("```" + response.output + "```");
       } else {
-        msg.channel.send("Unfortunately I was unable to run your code. Here is the error I received.\n```" + response.output + "```");
+        msg.channel.send(
+          "Unfortunately I was unable to run your code. Here is the error I received.\n```" +
+          response.output +
+          "```"
+        );
       }
-    })
+    });
 
   }
 
-  //Tries to pull language and source code out of message
+  // Tries to pull language and source code out of message
   private static parseCode(messageText: string): { language: string, code: string } {
-    let codeRegex = /(```(.[^\n]*))(\n(.*))(```)/s;
-    let match = codeRegex.exec(messageText);
+    const codeRegex = /(```(.[^\n]*))(\n(.*))(```)/s;
+    const match = codeRegex.exec(messageText);
 
-    //Group 2 = language, group 4 = code
+    // Group 2 = language, group 4 = code
     if (match && match[2] && match[4]) {
       return { language: match[2], code: match[4] };
     } else {
-      throw new Error(`Unable to extract code from ${messageText}`)
+      throw new Error(`Unable to extract code from ${messageText}`);
     }
   }
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -4,6 +4,8 @@ import axios, { AxiosResponse } from 'axios';
 import { Message } from 'discord.js';
 import { parse } from 'querystring';
 
+const languages = new Languages();
+
 // Hack for implementing with static properties/methods
 let Run: ICommand;
 export default Run = class {
@@ -13,15 +15,13 @@ export default Run = class {
     return 'Executes provided code using a LanguageRunner';
   }
 
-  public static execute(args: string[], msg: Message, extra: {
-    languages: Languages
-  }) {
+  public static execute(args: string[], msg: Message) {
 
     let parseResponse;
 
     try {
       parseResponse = this.parseCode(msg.content);
-      if (!extra.languages.get(parseResponse.language)) {
+      if (!languages.get(parseResponse.language)) {
         msg.channel.send(`Unknown language: ${parseResponse.language}`);
         return;
       }
@@ -30,9 +30,9 @@ export default Run = class {
       return;
     }
 
-    const codeRunnerResponse = extra.languages.get(parseResponse.language).execute(parseResponse.code);
+    const codeRunnerResponse = languages.get(parseResponse.language).execute(parseResponse.code);
 
-    codeRunnerResponse.then(response => {
+    codeRunnerResponse.then((response: { success: any; output: string; }) => {
       if (response.success) {
         msg.channel.send("```" + response.output + "```");
       } else {

--- a/src/commands/say.ts
+++ b/src/commands/say.ts
@@ -1,5 +1,5 @@
-import { Message } from 'discord.js';
 import ICommand from '@/library/interfaces/iCommand';
+import { Message } from 'discord.js';
 
 let Say: ICommand;
 

--- a/src/commands/source.ts
+++ b/src/commands/source.ts
@@ -1,5 +1,5 @@
-import { Message } from 'discord.js';
 import ICommand from '@/library/interfaces/iCommand';
+import { Message } from 'discord.js';
 
 let Source: ICommand;
 

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,7 +1,7 @@
 import config from '@/config';
+import ICommand from '@/library/interfaces/iCommand';
 import { version } from '@root/package.json';
 import { Message } from 'discord.js';
-import ICommand from '@/library/interfaces/iCommand';
 
 let Version: ICommand;
 

--- a/src/commands/weather.ts
+++ b/src/commands/weather.ts
@@ -1,7 +1,7 @@
-import axios, { AxiosResponse } from 'axios';
-import { Message } from 'discord.js';
 import config from '@/config';
 import ICommand from '@/library/interfaces/iCommand';
+import axios, { AxiosResponse } from 'axios';
+import { Message } from 'discord.js';
 
 let Weather: ICommand;
 

--- a/src/commands/xmas.ts
+++ b/src/commands/xmas.ts
@@ -1,5 +1,5 @@
-import { Message } from 'discord.js';
 import ICommand from '@/library/interfaces/iCommand';
+import { Message } from 'discord.js';
 
 let Xmas: ICommand;
 

--- a/src/library/core.ts
+++ b/src/library/core.ts
@@ -4,12 +4,19 @@ import glob from 'glob';
 import CommandLoader from './commandLoader';
 import CommandParser from './commandParser';
 import Commands from './commands';
+import LanguageLoader from './languageLoader';
+import Languages from './languages';
 
 const cmdParser = new CommandParser(config.messagePrefix);
 const commandsPathGlob = './src/commands/*.ts';
 const commandFiles = glob.sync(commandsPathGlob);
 const commandClasses = CommandLoader.getCommandClasses(commandFiles);
 const commands = new Commands(commandClasses);
+
+const languagesPathGlob = './src/runners/*.ts';
+const languageRunnerFiles = glob.sync(languagesPathGlob);
+const languageRunners = LanguageLoader.getLanguageClasses(languageRunnerFiles);
+const languages = new Languages(languageRunners);
 
 export default class Core {
 
@@ -38,7 +45,8 @@ export default class Core {
       if (command) {
         return command.execute(args, msg, {
           client: this.client,
-          commands
+          commands,
+          languages
         });
       }
       else {

--- a/src/library/core.ts
+++ b/src/library/core.ts
@@ -4,19 +4,12 @@ import glob from 'glob';
 import CommandLoader from './commandLoader';
 import CommandParser from './commandParser';
 import Commands from './commands';
-import LanguageLoader from './languageLoader';
-import Languages from './languages';
 
 const cmdParser = new CommandParser(config.messagePrefix);
 const commandsPathGlob = './src/commands/*.ts';
 const commandFiles = glob.sync(commandsPathGlob);
 const commandClasses = CommandLoader.getCommandClasses(commandFiles);
 const commands = new Commands(commandClasses);
-
-const languagesPathGlob = './src/runners/*.ts';
-const languageRunnerFiles = glob.sync(languagesPathGlob);
-const languageRunners = LanguageLoader.getLanguageClasses(languageRunnerFiles);
-const languages = new Languages(languageRunners);
 
 export default class Core {
 
@@ -45,8 +38,7 @@ export default class Core {
       if (command) {
         return command.execute(args, msg, {
           client: this.client,
-          commands,
-          languages
+          commands
         });
       }
       else {

--- a/src/library/interfaces/iCommand.ts
+++ b/src/library/interfaces/iCommand.ts
@@ -1,5 +1,6 @@
 import { Client, Message } from "discord.js";
 import Commands from "@/commands";
+import Langauges from "@/languages";
 
 /**
  * An interface for all commands to extend, representing the API that all
@@ -12,6 +13,7 @@ export default interface ICommand {
   readonly description: string;
   execute(args: string[], msg: Message, extra?: {
     client?: Client,
-    commands?: Commands
+    commands?: Commands,
+    languages?: Languages
   }): void;
 }

--- a/src/library/interfaces/iCommand.ts
+++ b/src/library/interfaces/iCommand.ts
@@ -1,6 +1,6 @@
 import { Client, Message } from "discord.js";
-import Commands from "@/commands";
-import Langauges from "@/languages";
+import Commands from "@/library/commands";
+import Languages from "@/library/languages";
 
 /**
  * An interface for all commands to extend, representing the API that all

--- a/src/library/interfaces/iCommand.ts
+++ b/src/library/interfaces/iCommand.ts
@@ -1,6 +1,6 @@
 import { Client, Message } from "discord.js";
 import Commands from "@/library/commands";
-import Languages from "@/library/languages";
+
 
 /**
  * An interface for all commands to extend, representing the API that all
@@ -13,7 +13,6 @@ export default interface ICommand {
   readonly description: string;
   execute(args: string[], msg: Message, extra?: {
     client?: Client,
-    commands?: Commands,
-    languages?: Languages
+    commands?: Commands
   }): void;
 }

--- a/src/library/interfaces/iRunner.ts
+++ b/src/library/interfaces/iRunner.ts
@@ -1,0 +1,10 @@
+/**
+ * An interface for all code runners to extend, representing the API that all
+ * subclasses should implement.
+ *
+ * @class Runner
+ */
+
+ export default interface IRunner {
+     execute(code: string): Promise<{success: boolean, output: string}>;
+ }

--- a/src/library/languageLoader.ts
+++ b/src/library/languageLoader.ts
@@ -2,7 +2,7 @@ import camelCase from 'lodash.camelcase';
 import path from 'path';
 import Runner from './interfaces/iRunner';
 
-export interface ILanguageRunners { [key: string]: Runner };
+export interface ILanguageRunners { [key: string]: Runner; }
 
 export default class LanguageLoader {
     public static getLanguageClasses(commandClassFiles: string[]): ILanguageRunners {

--- a/src/library/languageLoader.ts
+++ b/src/library/languageLoader.ts
@@ -1,0 +1,30 @@
+import camelCase from 'lodash.camelcase';
+import path from 'path';
+import Runner from './interfaces/iRunner';
+
+export interface ILanguageRunners { [key: string]: Runner };
+
+export default class LanguageLoader {
+    public static getLanguageClasses(commandClassFiles: string[]): ILanguageRunners {
+        /**
+         * https://stackoverflow.com/questions/5364928/node-js-require-all-files-in-a-folder
+         * Load all commands in the commands folder besides _template.js
+         */
+        const files = LanguageLoader.removeTemplateFile(commandClassFiles);
+        return files.reduce((prev: ILanguageRunners, file) => {
+            let key = path.basename(file, path.extname(file));
+            // Convert the kebab file names to camel case
+            key = camelCase(key);
+
+            const required = require(path.resolve(file));
+            prev[key] = required.default;
+
+            return prev;
+        }, {});
+    }
+
+    private static removeTemplateFile(files: string[]) {
+        const commandTemplateFile = './src/runners/_template.ts';
+        return files.filter(file => file !== commandTemplateFile);
+    }
+}

--- a/src/library/languages.ts
+++ b/src/library/languages.ts
@@ -1,0 +1,25 @@
+import { ILanguageRunners } from './languageLoader';
+import LanguageRunner from './interfaces/iRunner';
+
+export default class Commands {
+    public readonly all: ILanguageRunners;
+
+    constructor(languageRunners: ILanguageRunners) {
+        this.all = languageRunners;
+    }
+
+    get names() {
+        return Object.keys(this.all);
+    }
+
+    public get(languageName: string): LanguageRunner {
+        return this.all[languageName];
+    }
+
+    public longestNameLength() {
+        // Find the longest synopsis
+        const longest = this.names.sort((a, b) => b.length - a.length)[0];
+        return longest.length;
+    }
+
+}

--- a/src/library/languages.ts
+++ b/src/library/languages.ts
@@ -7,11 +7,8 @@ import LanguageLoader from './languageLoader';
 export default class Languages {
     public readonly all: ILanguageRunners;
 
-    constructor() {
-        const languagesPathGlob = './src/runners/*.ts';
-        const languageRunnerFiles = glob.sync(languagesPathGlob);
-        const languageRunners = LanguageLoader.getLanguageClasses(languageRunnerFiles);
-        this.all = languageRunners;
+    constructor(languages?: ILanguageRunners) {
+        this.all = languages || this.fetchLanguages();
     }
 
     get names() {
@@ -26,6 +23,12 @@ export default class Languages {
         // Find the longest synopsis
         const longest = this.names.sort((a, b) => b.length - a.length)[0];
         return longest.length;
+    }
+
+    private fetchLanguages(): ILanguageRunners {
+        const languagesPathGlob = './src/runners/*.ts';
+        const languageRunnerFiles = glob.sync(languagesPathGlob);
+        return LanguageLoader.getLanguageClasses(languageRunnerFiles);
     }
 
 }

--- a/src/library/languages.ts
+++ b/src/library/languages.ts
@@ -1,5 +1,5 @@
-import { ILanguageRunners } from './languageLoader';
 import LanguageRunner from './interfaces/iRunner';
+import { ILanguageRunners } from './languageLoader';
 
 export default class Commands {
     public readonly all: ILanguageRunners;

--- a/src/library/languages.ts
+++ b/src/library/languages.ts
@@ -1,10 +1,16 @@
 import LanguageRunner from './interfaces/iRunner';
 import { ILanguageRunners } from './languageLoader';
+import glob from 'glob';
+import LanguageLoader from './languageLoader';
 
-export default class Commands {
+
+export default class Languages {
     public readonly all: ILanguageRunners;
 
-    constructor(languageRunners: ILanguageRunners) {
+    constructor() {
+        const languagesPathGlob = './src/runners/*.ts';
+        const languageRunnerFiles = glob.sync(languagesPathGlob);
+        const languageRunners = LanguageLoader.getLanguageClasses(languageRunnerFiles);
         this.all = languageRunners;
     }
 
@@ -23,3 +29,5 @@ export default class Commands {
     }
 
 }
+
+

--- a/src/runners/_template.ts
+++ b/src/runners/_template.ts
@@ -5,4 +5,4 @@ export default LanguageName = class {
     public static execute(code: string): Promise<{success: boolean, output: string}> {
         throw new Error(`LanguageRunner not yet implemented for ${this.name}`);
     }
-}
+};

--- a/src/runners/_template.ts
+++ b/src/runners/_template.ts
@@ -1,0 +1,8 @@
+import IRunner from '@/library/interfaces/iRunner';
+
+let LanguageName: IRunner;
+export default LanguageName = class {
+    public static execute(code: string): Promise<{success: boolean, output: string}> {
+        throw new Error(`LanguageRunner not yet implemented for ${this.name}`);
+    }
+}

--- a/src/runners/rust.ts
+++ b/src/runners/rust.ts
@@ -17,12 +17,12 @@ export default Rust = class {
             });
     }
 
-    //Sends code to the rust playground for execution
+    // Sends code to the rust playground for execution
     private static runCode(code: string): Promise<{ success: boolean, stdout: string, stderr: string }> {
         const url = "https://play.rust-lang.org/execute";
         return axios.post(url, {
             channel: "stable",
-            code: code,
+            code,
             crateType: "bin",
             edition: "2018",
             mode: "debug",
@@ -32,7 +32,7 @@ export default Rust = class {
                 success: response.data.success,
                 stdout: response.data.stdout,
                 stderr: response.data.stderr
-            }
-        })
+            };
+        });
     }
-}
+};

--- a/src/runners/rust.ts
+++ b/src/runners/rust.ts
@@ -1,0 +1,38 @@
+import IRunner from '@/library/interfaces/iRunner';
+import axios, { AxiosResponse } from 'axios';
+
+let Rust: IRunner;
+export default Rust = class {
+    public static execute(code: string): Promise<{ success: boolean, output: string }> {
+        return this.runCode(code)
+            .then((response) => {
+                if (response.success) {
+                    return { success: true, output: response.stdout };
+                } else {
+                    return { success: false, output: response.stderr };
+                }
+            })
+            .catch(error => {
+                return { success: false, output: "Rust LanguageRunner encountered an internal error" };
+            });
+    }
+
+    //Sends code to the rust playground for execution
+    private static runCode(code: string): Promise<{ success: boolean, stdout: string, stderr: string }> {
+        const url = "https://play.rust-lang.org/execute";
+        return axios.post(url, {
+            channel: "stable",
+            code: code,
+            crateType: "bin",
+            edition: "2018",
+            mode: "debug",
+            tests: false
+        }).then((response: AxiosResponse) => {
+            return {
+                success: response.data.success,
+                stdout: response.data.stdout,
+                stderr: response.data.stderr
+            }
+        })
+    }
+}


### PR DESCRIPTION
Adds a run command that allows users to provide code for hackbot to run. Behind the scenes is system of LanguageRunners to execute code and provide the result. The whole LanguageRunner system is pretty much a copy and paste clone of the existing command system, so it should be familiar. Included in the commit is a LanguageRunner for rust.

I still need to add tests, so for now consider this PR as a discussion for improvements.

To use invoke the run command and provide a code block with a language name corresponding to the language hackbot should use to run it. The code block syntax follows all the rules of discord's codeblock, just make sure that there is a space between the command and the block. Also don't forget to specify the language.

Example input
![Example of command usage](https://i.imgur.com/mSk8ce3.png)

Example output
![Example of command output](https://i.imgur.com/Yb2cjRH.png)
It's just the stdout from the program inside a codeblock

